### PR TITLE
Add gradient logos with contrast-aware initials

### DIFF
--- a/aividz.online/logo.svg
+++ b/aividz.online/logo.svg
@@ -1,9 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="52" text-anchor="middle" fill="white">AI</text>
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="700" fill="#111827">AIVidz</text>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">A</text>
+
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0EA5E9">AIVidz</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">aividz.online</text>
   </g>
 </svg>

--- a/brands.yaml
+++ b/brands.yaml
@@ -1,4 +1,4 @@
-# brands.yml — edit me to change branding
+# brands.yaml — edit me to change branding
 brands:
   - id: aividz.online
     name: AIVidz
@@ -27,6 +27,8 @@ brands:
     bg_shape: circle
     primary: "#0F766E"  # teal
     accent:  "#0B1020"
+    gradient: true
+    gradient_angle: 45
 
   - id: speldridge
     name: Speldridge

--- a/fontofmadness.uk/logo.svg
+++ b/fontofmadness.uk/logo.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#4F46E5"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="42" text-anchor="middle" fill="white">FoM</text>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">FM</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#111827">Font of Madness</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">fontofmadness.uk</text>
   </g>

--- a/madgodnerevar.uk/logo.svg
+++ b/madgodnerevar.uk/logo.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#0EA5E9"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="36" text-anchor="middle" fill="white">MGN</text>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">M</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">MadGodNerevar</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">madgodnerevar.uk</text>
   </g>

--- a/nebula-project.org/logo.svg
+++ b/nebula-project.org/logo.svg
@@ -1,14 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
-    <circle cx="48" cy="48" r="48" fill="#0F766E"/>
-    <circle cx="48" cy="48" r="6" fill="white"/>
-    <g stroke="white" stroke-width="2">
-      <line x1="48" y1="48" x2="84" y2="28"/>
-      <line x1="48" y1="48" x2="20" y2="18"/>
-      <line x1="48" y1="48" x2="16" y2="76"/>
-      <line x1="48" y1="48" x2="80" y2="74"/>
-    </g>
+
+    <defs>
+      <linearGradient id="badgeGrad" x1="0.146" y1="0.146" x2="0.854" y2="0.854">
+        <stop offset="0%" stop-color="#0F766E"/>
+        <stop offset="100%" stop-color="#0B1020"/>
+      </linearGradient>
+    </defs>
+
+    <circle cx="48" cy="48" r="48" fill="url(#badgeGrad)"/>
+    <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">NP</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">Nebula Project</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">nebula-project.org</text>
   </g>

--- a/scripts/gen_logos.py
+++ b/scripts/gen_logos.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sys, json, yaml, textwrap
+import os, sys, json, yaml, textwrap, math
 
 ROOT = os.path.dirname(os.path.abspath(__file__)) + "/.."
 ROOT = os.path.normpath(ROOT)
@@ -15,23 +15,68 @@ TEMPLATE = """\
 </svg>
 """
 
-def badge_svg(shape, primary, accent, initials):
+def _hex_to_rgb(col):
+    col = col.lstrip("#")
+    r, g, b = int(col[0:2], 16) / 255.0, int(col[2:4], 16) / 255.0, int(col[4:6], 16) / 255.0
+    return r, g, b
+
+def _rel_lum(col):
+    def chan(c):
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+    r, g, b = _hex_to_rgb(col)
+    r, g, b = chan(r), chan(g), chan(b)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+def contrast_ratio(a, b):
+    l1, l2 = sorted([_rel_lum(a), _rel_lum(b)], reverse=True)
+    return (l1 + 0.05) / (l2 + 0.05)
+
+def pick_initials_color(primary, accent=None):
+    backgrounds = [primary]
+    if accent:
+        backgrounds.append(accent)
+    if all(contrast_ratio(bg, "#FFFFFF") >= 4.5 for bg in backgrounds):
+        return "white"
+    return "#111827"
+
+def _gradient_def(primary, accent, angle):
+    rad = math.radians(angle % 360)
+    x1 = 0.5 - 0.5 * math.cos(rad)
+    y1 = 0.5 - 0.5 * math.sin(rad)
+    x2 = 0.5 + 0.5 * math.cos(rad)
+    y2 = 0.5 + 0.5 * math.sin(rad)
+    return f"""
+    <defs>
+      <linearGradient id="badgeGrad" x1="{x1:.3f}" y1="{y1:.3f}" x2="{x2:.3f}" y2="{y2:.3f}">
+        <stop offset="0%" stop-color="{primary}"/>
+        <stop offset="100%" stop-color="{accent}"/>
+      </linearGradient>
+    </defs>
+"""
+
+def badge_svg(shape, primary, accent, initials, use_gradient=False, gradient_angle=0):
+    defs = ""
+    fill = primary
+    if use_gradient:
+        defs = _gradient_def(primary, accent, gradient_angle)
+        fill = "url(#badgeGrad)"
+    text_color = pick_initials_color(primary, accent if use_gradient else None)
     if shape == "circle":
-        return f"""
-    <circle cx="48" cy="48" r="48" fill="{primary}"/>
-    <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">{initials}</text>
+        return f"""{defs}
+    <circle cx="48" cy="48" r="48" fill="{fill}"/>
+    <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="{text_color}">{initials}</text>
 """
     elif shape == "diamond":
-        return f"""
+        return f"""{defs}
     <g transform="translate(0,0)">
-      <rect x="0" y="0" width="96" height="96" fill="{primary}" transform="translate(48,48) rotate(45) translate(-48,-48)" rx="16" ry="16"/>
-      <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="36" text-anchor="middle" fill="white">{initials}</text>
+      <rect x="0" y="0" width="96" height="96" fill="{fill}" transform="translate(48,48) rotate(45) translate(-48,-48)" rx="16" ry="16"/>
+      <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="36" text-anchor="middle" fill="{text_color}">{initials}</text>
     </g>
 """
     else:  # rounded
-        return f"""
-    <rect rx="16" ry="16" width="96" height="96" fill="{primary}"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">{initials}</text>
+        return f"""{defs}
+    <rect rx="16" ry="16" width="96" height="96" fill="{fill}"/>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="{text_color}">{initials}</text>
 """
 
 def initials_from_name(name):
@@ -51,7 +96,7 @@ def save_svg(path, svg):
         f.write(svg)
 
 def main():
-    cfg_path = os.path.join(ROOT, "brands.yml")
+    cfg_path = os.path.join(ROOT, "brands.yaml")
     with open(cfg_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
@@ -59,7 +104,14 @@ def main():
         folder = os.path.join(ROOT, b["id"])
         os.makedirs(folder, exist_ok=True)
         initials = initials_from_name(b["name"])
-        badge = badge_svg(b.get("bg_shape","rounded"), b.get("primary","#111827"), b.get("accent","#6B7280"), initials)
+        badge = badge_svg(
+            b.get("bg_shape", "rounded"),
+            b.get("primary", "#111827"),
+            b.get("accent", "#6B7280"),
+            initials,
+            b.get("gradient", False),
+            b.get("gradient_angle", 0),
+        )
         svg = TEMPLATE.format(
             badge=badge,
             title_color=b.get("accent","#111827"),

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -1,9 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">SE</text>
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#111827">Speldridge</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">.co.uk · .tech</text>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">S</text>
+
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6B7280">Speldridge</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.co.uk · .tech</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- support optional linear gradients in badges via new `gradient` and `gradient_angle` fields
- automatically adjust badge initials color for WCAG contrast
- regenerate logos using new settings (Nebula Project now uses a gradient)

## Testing
- `pip install pyyaml`
- `python scripts/gen_logos.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb66f064c8328b883407c6ab1ccb7