### PR TITLE
refactor: streamline brand gradient settings

### DIFF
--- a/brands.yaml
+++ b/brands.yaml
@@ -18,9 +18,6 @@ brands:
     primary: "#4F46E5"  # purple
     accent:  "#111827"
     use_gradient: false
-    gradient_from: null
-    gradient_to: null
-    gradient_angle: 0
 
   - id: madgodnerevar.uk
     name: MadGodNerevar
@@ -29,9 +26,6 @@ brands:
     primary: "#0EA5E9"
     accent:  "#0B1020"
     use_gradient: false
-    gradient_from: null
-    gradient_to: null
-    gradient_angle: 0
 
   - id: nebula-project.org
     name: Nebula Project
@@ -39,7 +33,9 @@ brands:
     bg_shape: circle
     primary: "#0F766E"  # teal
     accent:  "#0B1020"
-    gradient: true
+    use_gradient: true
+    gradient_from: "#0F766E"
+    gradient_to: "#0B1020"
     gradient_angle: 45
 
   - id: speldridge
@@ -49,6 +45,3 @@ brands:
     primary: "#111827"
     accent:  "#6B7280"
     use_gradient: false
-    gradient_from: null
-    gradient_to: null
-    gradient_angle: 0


### PR DESCRIPTION
## Summary
- remove unused gradient fields for brands without gradients
- configure Nebula Project gradient using `use_gradient` and explicit colors

## Testing
- `python -m py_compile scripts/gen_logos.py`
- `python - <<'PY' import yaml; yaml.safe_load(open('brands.yaml')); print('YAML OK') PY`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbc23baec8328a712baf8f448aa50