### PR TITLE
Add gradient color parameters to logo generator

### DIFF
--- a/aividz.online/logo.svg
+++ b/aividz.online/logo.svg
@@ -1,9 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
-    <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">A</text>
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0EA5E9">AIVidz</text>
+
+    <defs>
+      <linearGradient id="badgeGrad" x1="0.854" y1="0.146" x2="0.146" y2="0.854">
+        <stop offset="0%" stop-color="#00BFA5"/>
+        <stop offset="100%" stop-color="#7C4DFF"/>
+      </linearGradient>
+    </defs>
+
+    <rect rx="16" ry="16" width="96" height="96" fill="url(#badgeGrad)"/>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">A</text>
+
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#00BFA5">AIVidz</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">aividz.online</text>
   </g>
 </svg>

--- a/brands.yaml
+++ b/brands.yaml
@@ -39,7 +39,9 @@ brands:
     bg_shape: circle
     primary: "#0F766E"  # teal
     accent:  "#0B1020"
-    gradient: true
+    use_gradient: true
+    gradient_from: "#0F766E"
+    gradient_to: "#0B1020"
     gradient_angle: 45
 
   - id: speldridge

--- a/fontofmadness.uk/logo.svg
+++ b/fontofmadness.uk/logo.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#4F46E5"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">FM</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#111827">Font of Madness</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">fontofmadness.uk</text>
   </g>

--- a/madgodnerevar.uk/logo.svg
+++ b/madgodnerevar.uk/logo.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#0EA5E9"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">M</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">MadGodNerevar</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">madgodnerevar.uk</text>
   </g>

--- a/nebula-project.org/logo.svg
+++ b/nebula-project.org/logo.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <defs>
       <linearGradient id="badgeGrad" x1="0.146" y1="0.146" x2="0.854" y2="0.854">
         <stop offset="0%" stop-color="#0F766E"/>
@@ -10,6 +11,7 @@
 
     <circle cx="48" cy="48" r="48" fill="url(#badgeGrad)"/>
     <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">NP</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">Nebula Project</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">nebula-project.org</text>
   </g>

--- a/scripts/gen_logos.py
+++ b/scripts/gen_logos.py
@@ -39,7 +39,7 @@ def pick_initials_color(primary, accent=None):
         return "white"
     return "#111827"
 
-def _gradient_def(primary, accent, angle):
+def _gradient_def(gradient_from, gradient_to, angle):
     rad = math.radians(angle % 360)
     x1 = 0.5 - 0.5 * math.cos(rad)
     y1 = 0.5 - 0.5 * math.sin(rad)
@@ -48,19 +48,19 @@ def _gradient_def(primary, accent, angle):
     return f"""
     <defs>
       <linearGradient id="badgeGrad" x1="{x1:.3f}" y1="{y1:.3f}" x2="{x2:.3f}" y2="{y2:.3f}">
-        <stop offset="0%" stop-color="{primary}"/>
-        <stop offset="100%" stop-color="{accent}"/>
+        <stop offset="0%" stop-color="{gradient_from}"/>
+        <stop offset="100%" stop-color="{gradient_to}"/>
       </linearGradient>
     </defs>
 """
 
-def badge_svg(shape, primary, accent, initials, use_gradient=False, gradient_angle=0):
+def badge_svg(shape, primary, accent, initials, use_gradient=False, gradient_from=None, gradient_to=None, gradient_angle=0):
     defs = ""
     fill = primary
     if use_gradient:
-        defs = _gradient_def(primary, accent, gradient_angle)
+        defs = _gradient_def(gradient_from or primary, gradient_to or accent, gradient_angle)
         fill = "url(#badgeGrad)"
-    text_color = pick_initials_color(primary, accent if use_gradient else None)
+    text_color = pick_initials_color(gradient_from or primary, (gradient_to or accent) if use_gradient else None)
     if shape == "circle":
         return f"""{defs}
     <circle cx="48" cy="48" r="48" fill="{fill}"/>
@@ -109,7 +109,9 @@ def main():
             b.get("primary", "#111827"),
             b.get("accent", "#6B7280"),
             initials,
-            b.get("gradient", False),
+            b.get("use_gradient", False),
+            b.get("gradient_from"),
+            b.get("gradient_to"),
             b.get("gradient_angle", 0),
         )
         svg = TEMPLATE.format(

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">S</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6B7280">Speldridge</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldidge.tech · speldridge.co.uk</text>
   </g>


### PR DESCRIPTION
## Summary
- extend logo generator to accept `gradient_from`/`gradient_to` and new `use_gradient` flag
- allow custom gradient angles and update brand configs
- regenerate brand SVGs using new gradient logic

## Testing
- `python scripts/gen_logos.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bbc25f6848328ac1fe371c512d405