### PR TITLE
Handle camel case and non-letter initials

### DIFF
--- a/scripts/gen_logos.py
+++ b/scripts/gen_logos.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sys, json, yaml, textwrap, math
+import os, sys, json, yaml, textwrap, math, re
 
 ROOT = os.path.dirname(os.path.abspath(__file__)) + "/.."
 ROOT = os.path.normpath(ROOT)
@@ -80,14 +80,25 @@ def badge_svg(shape, primary, accent, initials, use_gradient=False, gradient_ang
 """
 
 def initials_from_name(name):
-    parts = [p for p in name.split() if p and p[0].isalnum()]
-    if not parts: return "•"
-    # e.g., "Font of Madness" -> "FoM"
+    """Return up to three initials derived from *name*.
+
+    Splits the input on whitespace, non-letter transitions, and camelCase
+    boundaries. Small connector words are ignored. If no letters are found a
+    bullet "\u2022" is returned.
+    """
+
+    tokens = re.findall(r"[A-Z]+(?![a-z])|[A-Z][a-z]*|[a-z]+", name)
+    if not tokens:
+        return "•"
+
     letters = []
-    for p in parts:
-        if p.lower() in {"of","and","the","a","an"}:  # skip small words
+    for tok in tokens:
+        if tok.lower() in {"of", "and", "the", "a", "an"}:
             continue
-        letters.append(p[0])
+        letters.append(tok[0])
+        if len(letters) == 3:
+            break
+
     s = "".join(letters) or name[0]
     return s[:3]
 

--- a/tests/test_initials.py
+++ b/tests/test_initials.py
@@ -1,0 +1,12 @@
+import sys, pathlib
+
+# Add scripts directory to path to import gen_logos
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+from gen_logos import initials_from_name
+
+def test_camelcase_split():
+    assert initials_from_name('AIVidz') == 'AV'
+
+def test_non_letter_and_limit():
+    assert initials_from_name('AI-Vidz') == 'AV'
+    assert initials_from_name('OneTwoThreeFour') == 'OTT'


### PR DESCRIPTION
## Summary
- Support splitting names on camelCase and non-letter boundaries when generating initials
- Add tests for camelCase, non-letter transitions, and length limiting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bbc272f8c83288597f52151c4ddbe