### PR TITLE
Fix Speldridge domain and regenerate logo

### DIFF
--- a/brands.yaml
+++ b/brands.yaml
@@ -44,7 +44,7 @@ brands:
 
   - id: speldridge
     name: Speldridge
-    domain: "speldidge.tech · speldridge.co.uk"
+    domain: "speldridge.tech · speldridge.co.uk"
     bg_shape: rounded
     primary: "#111827"
     accent:  "#6B7280"

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -1,9 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220">
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
+
     <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">S</text>
+
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6B7280">Speldridge</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldidge.tech · speldridge.co.uk</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.tech · speldridge.co.uk</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- correct Speldridge domain in `brands.yaml`
- regenerate Speldridge logo to use updated domain

## Testing
- `python scripts/gen_logos.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbc29a9e48328b067edad600fb75c