### PR TITLE
ci: stash before pulling during PNG render

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -71,7 +71,10 @@ jobs:
           inkscape logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
           ls -l
 
-      - run: git pull --rebase origin main
+      - run: |
+          git stash --include-untracked
+          git pull --rebase origin main
+          git stash pop
 
       - name: Commit rendered images
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary
- stash and reapply local PNG changes around git pull in render workflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689bc42f3cd48328a6f6a0e4de9820a3