### PR TITLE
Add brand-specific email signature templates

### DIFF
--- a/aividz.online/signature/index.html
+++ b/aividz.online/signature/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Signature</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #00BFA5;">
+  <img src="../logo.png" width="160" alt="AIVidz logo">
+  <p>
+    <strong>Full Name</strong><br>
+    Title<br>
+    <a href="mailto:email@example.com" style="color: #794BC4; text-decoration: none;">email@example.com</a><br>
+    <span style="color: #794BC4;">+1 234 567 890</span>
+  </p>
+</body>
+</html>

--- a/fontofmadness.uk/signature/index.html
+++ b/fontofmadness.uk/signature/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Signature</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #4F46E5;">
+  <img src="../logo.png" width="160" alt="Font of Madness logo">
+  <p>
+    <strong>Full Name</strong><br>
+    Title<br>
+    <a href="mailto:email@example.com" style="color: #111827; text-decoration: none;">email@example.com</a><br>
+    <span style="color: #111827;">+1 234 567 890</span>
+  </p>
+</body>
+</html>

--- a/madgodnerevar.uk/signature/index.html
+++ b/madgodnerevar.uk/signature/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Signature</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #0EA5E9;">
+  <img src="../logo.png" width="160" alt="MadGodNerevar logo">
+  <p>
+    <strong>Full Name</strong><br>
+    Title<br>
+    <a href="mailto:email@example.com" style="color: #0B1020; text-decoration: none;">email@example.com</a><br>
+    <span style="color: #0B1020;">+1 234 567 890</span>
+  </p>
+</body>
+</html>

--- a/nebula-project.org/signature/index.html
+++ b/nebula-project.org/signature/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Signature</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #0F766E;">
+  <img src="../logo.png" width="160" alt="Nebula Project logo">
+  <p>
+    <strong>Full Name</strong><br>
+    Title<br>
+    <a href="mailto:email@example.com" style="color: #0B1020; text-decoration: none;">email@example.com</a><br>
+    <span style="color: #0B1020;">+1 234 567 890</span>
+  </p>
+</body>
+</html>

--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Signature</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #111827;">
+  <img src="../logo.png" width="160" alt="Speldridge logo">
+  <p>
+    <strong>Full Name</strong><br>
+    Title<br>
+    <a href="mailto:email@example.com" style="color: #6B7280; text-decoration: none;">email@example.com</a><br>
+    <span style="color: #6B7280;">+1 234 567 890</span>
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML email signature templates for each brand with logo, brand colors, and contact placeholders

## Testing
- `for f in aividz.online fontofmadness.uk madgodnerevar.uk nebula-project.org speldridge; do tidy -q -errors $f/signature/index.html; done`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bca1b100483288d7a9d248cc53d19