### PR TITLE
Refresh brand palettes for AIVidz, Nebula Project, and Speldridge

### DIFF
--- a/aividz.online/logo.svg
+++ b/aividz.online/logo.svg
@@ -4,15 +4,15 @@
 
     <defs>
       <linearGradient id="badgeGrad" x1="0.854" y1="0.146" x2="0.146" y2="0.854">
-        <stop offset="0%" stop-color="#00BFA5"/>
-        <stop offset="100%" stop-color="#794BC4"/>
+        <stop offset="0%" stop-color="#111C2E"/>
+        <stop offset="100%" stop-color="#2C145B"/>
       </linearGradient>
     </defs>
 
     <rect rx="16" ry="16" width="96" height="96" fill="url(#badgeGrad)"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">AV</text>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">AV</text>
 
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#794BC4">AIVidz</text>
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#00BFA5">AIVidz</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">aividz.online</text>
   </g>
 </svg>

--- a/brands.yaml
+++ b/brands.yaml
@@ -4,11 +4,11 @@ brands:
     name: AIVidz
     domain: aividz.online
     bg_shape: rounded
-    primary: "#00BFA5"
-    accent:  "#794BC4"
+    primary: "#101D2E"
+    accent:  "#00BFA5"
     use_gradient: true
-    gradient_from: "#00BFA5"
-    gradient_to: "#794BC4"
+    gradient_from: "#111C2E"
+    gradient_to: "#2C145B"
     gradient_angle: 135
 
   - id: fontofmadness.uk
@@ -31,17 +31,20 @@ brands:
     name: Nebula Project
     domain: nebula-project.org
     bg_shape: circle
-    primary: "#0F766E"
-    accent:  "#0B1020"
+    primary: "#1A202C"
+    accent:  "#62EFFF"
     use_gradient: true
-    gradient_from: "#0F766E"
-    gradient_to: "#0B1020"
-    gradient_angle: 45
+    gradient_from: "#62EFFF"
+    gradient_to: "#B388FF"
+    gradient_angle: 90
 
   - id: speldridge
     name: Speldridge
     domain: "speldridge.tech · speldridge.co.uk"
     bg_shape: rounded
-    primary: "#111827"
-    accent:  "#6B7280"
-    use_gradient: false
+    primary: "#100629"
+    accent:  "#6C2EB7"
+    use_gradient: true
+    gradient_from: "#6C2EB7"
+    gradient_to: "#00DACB"
+    gradient_angle: 135

--- a/nebula-project.org/logo.svg
+++ b/nebula-project.org/logo.svg
@@ -3,16 +3,16 @@
   <g transform="translate(24,24)">
 
     <defs>
-      <linearGradient id="badgeGrad" x1="0.146" y1="0.146" x2="0.854" y2="0.854">
-        <stop offset="0%" stop-color="#0F766E"/>
-        <stop offset="100%" stop-color="#0B1020"/>
+      <linearGradient id="badgeGrad" x1="0.500" y1="0.000" x2="0.500" y2="1.000">
+        <stop offset="0%" stop-color="#62EFFF"/>
+        <stop offset="100%" stop-color="#B388FF"/>
       </linearGradient>
     </defs>
 
     <circle cx="48" cy="48" r="48" fill="url(#badgeGrad)"/>
-    <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">NP</text>
+    <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">NP</text>
 
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">Nebula Project</text>
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#62EFFF">Nebula Project</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">nebula-project.org</text>
   </g>
 </svg>

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -2,10 +2,17 @@
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
 
-    <rect rx="16" ry="16" width="96" height="96" fill="#111827"/>
-    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">S</text>
+    <defs>
+      <linearGradient id="badgeGrad" x1="0.854" y1="0.146" x2="0.146" y2="0.854">
+        <stop offset="0%" stop-color="#6C2EB7"/>
+        <stop offset="100%" stop-color="#00DACB"/>
+      </linearGradient>
+    </defs>
 
-    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6B7280">Speldridge</text>
+    <rect rx="16" ry="16" width="96" height="96" fill="url(#badgeGrad)"/>
+    <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">S</text>
+
+    <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6C2EB7">Speldridge</text>
     <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.tech · speldridge.co.uk</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- update AIVidz colors and hero gradient
- adjust Nebula Project palette and gradient angle
- replace Speldridge placeholder colors with site palette

## Testing
- `python scripts/gen_logos.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bca1954f483289d7fda51064ec552