### PR TITLE
Add table layout email signatures for all brands

### DIFF
--- a/aividz.online/signature/index.html
+++ b/aividz.online/signature/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title></title>
+</head>
+<body style="margin:0;">
+<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+  <tr>
+    <td style="padding-right:16px;">
+      <a href="https://aividz.online" target="_blank">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/aividz.online/logo.png" alt="AIVidz logo" style="display:block;border:0;" />
+      </a>
+    </td>
+    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
+      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="color:#444;">%%Title%%</div>
+      <div style="color:#444;">%%Company%%</div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/fontofmadness.uk/signature/index.html
+++ b/fontofmadness.uk/signature/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title></title>
+</head>
+<body style="margin:0;">
+<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+  <tr>
+    <td style="padding-right:16px;">
+      <a href="https://fontofmadness.uk" target="_blank">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/fontofmadness.uk/logo.png" alt="Font of Madness logo" style="display:block;border:0;" />
+      </a>
+    </td>
+    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
+      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="color:#444;">%%Title%%</div>
+      <div style="color:#444;">%%Company%%</div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://fontofmadness.uk" style="color:#0b57d0;text-decoration:none;">fontofmadness.uk</a></div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/madgodnerevar.uk/signature/index.html
+++ b/madgodnerevar.uk/signature/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title></title>
+</head>
+<body style="margin:0;">
+<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+  <tr>
+    <td style="padding-right:16px;">
+      <a href="https://madgodnerevar.uk" target="_blank">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/madgodnerevar.uk/logo.png" alt="MadGodNerevar logo" style="display:block;border:0;" />
+      </a>
+    </td>
+    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
+      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="color:#444;">%%Title%%</div>
+      <div style="color:#444;">%%Company%%</div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://madgodnerevar.uk" style="color:#0b57d0;text-decoration:none;">madgodnerevar.uk</a></div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/nebula-project.org/signature/index.html
+++ b/nebula-project.org/signature/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title></title>
+</head>
+<body style="margin:0;">
+<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+  <tr>
+    <td style="padding-right:16px;">
+      <a href="https://nebula-project.org" target="_blank">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/nebula-project.org/logo.png" alt="Nebula Project logo" style="display:block;border:0;" />
+      </a>
+    </td>
+    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
+      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="color:#444;">%%Title%%</div>
+      <div style="color:#444;">%%Company%%</div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://nebula-project.org" style="color:#0b57d0;text-decoration:none;">nebula-project.org</a></div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title></title>
+</head>
+<body style="margin:0;">
+<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+  <tr>
+    <td style="padding-right:16px;">
+      <a href="https://speldridge.tech" target="_blank">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/speldridge/logo.png" alt="Speldridge logo" style="display:block;border:0;" />
+      </a>
+    </td>
+    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
+      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="color:#444;">%%Title%%</div>
+      <div style="color:#444;">%%Company%%</div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://speldridge.tech" style="color:#0b57d0;text-decoration:none;">speldridge.tech</a></div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add presentation-table email signature templates for all brand folders
- include linked logos, placeholders, and brand-specific links

## Testing
- `tidy -q -errors aividz.online/signature/index.html`
- `tidy -q -errors fontofmadness.uk/signature/index.html`
- `tidy -q -errors madgodnerevar.uk/signature/index.html`
- `tidy -q -errors nebula-project.org/signature/index.html`
- `tidy -q -errors speldridge/signature/index.html`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcc075c18832894eded889ae3ab57