### PR TITLE
ci: handle empty stash in render workflow

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -72,9 +72,9 @@ jobs:
           ls -l
 
       - run: |
-          git stash --include-untracked
+          git stash --include-untracked || true
           git pull --rebase origin main
-          git stash pop
+          git stash pop || true
 
       - name: Commit rendered images
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary
- guard git stash commands in render-signatures workflow to avoid failures when there are no changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcef71d348328912d5ec0ceeea240