### PR TITLE
ci: rebase before rendering signatures

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Rebase onto latest main
+        run: git pull --rebase --autostash origin main
+
       - name: Install Inkscape
         run: |
           sudo apt-get update
@@ -70,11 +73,6 @@ jobs:
           inkscape logo.svg --export-type=png --export-filename=logo.png   -w 320 --export-area-drawing
           inkscape logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
           ls -l
-
-      - run: |
-          git stash --include-untracked
-          git pull --rebase origin main
-          git stash pop
 
       - name: Commit rendered images
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary
- rebase before rendering signatures with `--autostash`
- remove manual stashing during render workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcef8c5048328b714f16f7c263bb3