### PR TITLE
chore(workflow): silence Inkscape portal warnings

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -67,8 +67,8 @@ jobs:
         working-directory: ./${{ matrix.folder }}
         run: |
           set -euo pipefail
-          inkscape logo.svg --export-type=png --export-filename=logo.png   -w 320 --export-area-drawing
-          inkscape logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
+          GTK_USE_PORTAL=0 inkscape logo.svg --export-type=png --export-filename=logo.png   -w 320 --export-area-drawing
+          GTK_USE_PORTAL=0 inkscape logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
           ls -l
 
       - run: |


### PR DESCRIPTION
## Summary
- set `GTK_USE_PORTAL=0` for Inkscape PNG export in render-signatures workflow to suppress GtkRecentManager chatter

## Testing
- `pytest -q`
- `GTK_USE_PORTAL=0 inkscape aividz.online/logo.svg --export-type=png --export-filename=/tmp/logo.png -w 320 --export-area-drawing`

------
https://chatgpt.com/codex/tasks/task_e_689bcefbf628832890d0184018dbe8c4