### PR TITLE
chore(workflow): ensure generate-svgs can push SVGs

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   generate-svgs:
+    # Needed so the job can push regenerated SVGs
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- clarify generate-svgs workflow permissions so it can push regenerated SVGs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bd5d2b0c483288c143377f9cabf68