### PR TITLE
Stack contact info above logos in signatures

### DIFF
--- a/aividz.online/signature/index.html
+++ b/aividz.online/signature/index.html
@@ -5,21 +5,17 @@
 <title></title>
 </head>
 <body style="margin:0;">
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-  <tr>
-    <td style="padding-right:16px;">
-      <a href="https://aividz.online" target="_blank">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/aividz.online/logo.png" alt="AIVidz logo" style="display:block;border:0;" />
-      </a>
-    </td>
-    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
-    </td>
-  </tr>
-</table>
+<div style="display:flex;flex-direction:column;align-items:center;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
+  <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+  <div style="color:#444;">%%Title%%</div>
+  <div style="color:#444;">%%Company%%</div>
+  <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+  <div><a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
+  <div style="margin-top:16px;">
+    <a href="https://aividz.online" target="_blank">
+      <img src="../logo.png" alt="AIVidz logo" style="display:block;border:0;width:160px;" />
+    </a>
+  </div>
+</div>
 </body>
 </html>

--- a/fontofmadness.uk/signature/index.html
+++ b/fontofmadness.uk/signature/index.html
@@ -5,21 +5,17 @@
 <title></title>
 </head>
 <body style="margin:0;">
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-  <tr>
-    <td style="padding-right:16px;">
-      <a href="https://fontofmadness.uk" target="_blank">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/fontofmadness.uk/logo.png" alt="Font of Madness logo" style="display:block;border:0;" />
-      </a>
-    </td>
-    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://fontofmadness.uk" style="color:#0b57d0;text-decoration:none;">fontofmadness.uk</a></div>
-    </td>
-  </tr>
-</table>
+<div style="display:flex;flex-direction:column;align-items:center;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
+  <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+  <div style="color:#444;">%%Title%%</div>
+  <div style="color:#444;">%%Company%%</div>
+  <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+  <div><a href="https://fontofmadness.uk" style="color:#0b57d0;text-decoration:none;">fontofmadness.uk</a></div>
+  <div style="margin-top:16px;">
+    <a href="https://fontofmadness.uk" target="_blank">
+      <img src="../logo.png" alt="Font of Madness logo" style="display:block;border:0;width:160px;" />
+    </a>
+  </div>
+</div>
 </body>
 </html>

--- a/madgodnerevar.uk/signature/index.html
+++ b/madgodnerevar.uk/signature/index.html
@@ -5,21 +5,17 @@
 <title></title>
 </head>
 <body style="margin:0;">
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-  <tr>
-    <td style="padding-right:16px;">
-      <a href="https://madgodnerevar.uk" target="_blank">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/madgodnerevar.uk/logo.png" alt="MadGodNerevar logo" style="display:block;border:0;" />
-      </a>
-    </td>
-    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://madgodnerevar.uk" style="color:#0b57d0;text-decoration:none;">madgodnerevar.uk</a></div>
-    </td>
-  </tr>
-</table>
+<div style="display:flex;flex-direction:column;align-items:center;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
+  <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+  <div style="color:#444;">%%Title%%</div>
+  <div style="color:#444;">%%Company%%</div>
+  <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+  <div><a href="https://madgodnerevar.uk" style="color:#0b57d0;text-decoration:none;">madgodnerevar.uk</a></div>
+  <div style="margin-top:16px;">
+    <a href="https://madgodnerevar.uk" target="_blank">
+      <img src="../logo.png" alt="MadGodNerevar logo" style="display:block;border:0;width:160px;" />
+    </a>
+  </div>
+</div>
 </body>
 </html>

--- a/nebula-project.org/signature/index.html
+++ b/nebula-project.org/signature/index.html
@@ -5,21 +5,17 @@
 <title></title>
 </head>
 <body style="margin:0;">
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-  <tr>
-    <td style="padding-right:16px;">
-      <a href="https://nebula-project.org" target="_blank">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/nebula-project.org/logo.png" alt="Nebula Project logo" style="display:block;border:0;" />
-      </a>
-    </td>
-    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://nebula-project.org" style="color:#0b57d0;text-decoration:none;">nebula-project.org</a></div>
-    </td>
-  </tr>
-</table>
+<div style="display:flex;flex-direction:column;align-items:center;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
+  <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+  <div style="color:#444;">%%Title%%</div>
+  <div style="color:#444;">%%Company%%</div>
+  <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+  <div><a href="https://nebula-project.org" style="color:#0b57d0;text-decoration:none;">nebula-project.org</a></div>
+  <div style="margin-top:16px;">
+    <a href="https://nebula-project.org" target="_blank">
+      <img src="../logo.png" alt="Nebula Project logo" style="display:block;border:0;width:160px;" />
+    </a>
+  </div>
+</div>
 </body>
 </html>

--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -5,21 +5,17 @@
 <title></title>
 </head>
 <body style="margin:0;">
-<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
-  <tr>
-    <td style="padding-right:16px;">
-      <a href="https://speldridge.tech" target="_blank">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/speldridge/logo.png" alt="Speldridge logo" style="display:block;border:0;" />
-      </a>
-    </td>
-    <td style="font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://speldridge.tech" style="color:#0b57d0;text-decoration:none;">speldridge.tech</a></div>
-    </td>
-  </tr>
-</table>
+<div style="display:flex;flex-direction:column;align-items:center;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
+  <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+  <div style="color:#444;">%%Title%%</div>
+  <div style="color:#444;">%%Company%%</div>
+  <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+  <div><a href="https://speldridge.tech" style="color:#0b57d0;text-decoration:none;">speldridge.tech</a></div>
+  <div style="margin-top:16px;">
+    <a href="https://speldridge.tech" target="_blank">
+      <img src="../logo.png" alt="Speldridge logo" style="display:block;border:0;width:160px;" />
+    </a>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- stack contact details above brand logo for each signature
- center content with a flex column layout while preserving fonts and colors

## Testing
- `pytest`
- `w3m -dump aividz.online/signature/index.html | head -n 20`
- `w3m -dump fontofmadness.uk/signature/index.html | head -n 20`
- `w3m -dump madgodnerevar.uk/signature/index.html | head -n 20`
- `w3m -dump nebula-project.org/signature/index.html | head -n 20`
- `w3m -dump speldridge/signature/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689bda40013083289d06b45b917184bc