### PR TITLE
Regenerate brand logos

### DIFF
--- a/fontofmadness.uk/logo.svg
+++ b/fontofmadness.uk/logo.svg
@@ -2,7 +2,14 @@
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
 
-    <rect rx="16" ry="16" width="96" height="96" fill="#4F46E5"/>
+    <defs>
+      <linearGradient id="badgeGrad" x1="0.146" y1="0.146" x2="0.854" y2="0.854">
+        <stop offset="0%" stop-color="#4F46E5"/>
+        <stop offset="100%" stop-color="#111827"/>
+      </linearGradient>
+    </defs>
+
+    <rect rx="16" ry="16" width="96" height="96" fill="url(#badgeGrad)"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">FM</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#111827">Font of Madness</text>

--- a/madgodnerevar.uk/logo.svg
+++ b/madgodnerevar.uk/logo.svg
@@ -2,7 +2,14 @@
   <rect width="100%" height="100%" fill="white"/>
   <g transform="translate(24,24)">
 
-    <rect rx="16" ry="16" width="96" height="96" fill="#0EA5E9"/>
+    <defs>
+      <linearGradient id="badgeGrad" x1="1.000" y1="0.500" x2="0.000" y2="0.500">
+        <stop offset="0%" stop-color="#0EA5E9"/>
+        <stop offset="100%" stop-color="#0B1020"/>
+      </linearGradient>
+    </defs>
+
+    <rect rx="16" ry="16" width="96" height="96" fill="url(#badgeGrad)"/>
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">MGN</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">MadGodNerevar</text>

--- a/nebula-project.org/logo.svg
+++ b/nebula-project.org/logo.svg
@@ -3,7 +3,7 @@
   <g transform="translate(24,24)">
 
     <defs>
-      <linearGradient id="badgeGrad" x1="0.500" y1="0.000" x2="0.500" y2="1.000">
+      <linearGradient id="badgeGrad" x1="0.854" y1="0.146" x2="0.146" y2="0.854">
         <stop offset="0%" stop-color="#62EFFF"/>
         <stop offset="100%" stop-color="#B388FF"/>
       </linearGradient>

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -3,7 +3,7 @@
   <g transform="translate(24,24)">
 
     <defs>
-      <linearGradient id="badgeGrad" x1="0.854" y1="0.146" x2="0.146" y2="0.854">
+      <linearGradient id="badgeGrad" x1="0.000" y1="0.500" x2="1.000" y2="0.500">
         <stop offset="0%" stop-color="#6C2EB7"/>
         <stop offset="100%" stop-color="#00DACB"/>
       </linearGradient>
@@ -13,6 +13,6 @@
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">S</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6C2EB7">Speldridge</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.tech · speldridge.co.uk</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.co.uk · .tech</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- regenerate Font of Madness, MadGodNerevar, Nebula Project, and Speldridge logo SVGs from branding spec
- ensure 800x220 canvas with gradients and shapes matching configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c51f962148328b9db5c5aee10f580