### PR TITLE
Rearrange Speldridge signature layout

### DIFF
--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -1,17 +1,19 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;">
   <tr>
-    <td style="padding:0 10px 0 0;">
-      <a href="https://speldridge.co.uk" target="_blank" style="text-decoration:none;">
-        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/speldridge/logo.png"
-             alt="Speldridge" style="width:160px;height:auto;border:none;display:block;">
-      </a>
-    </td>
-    <td style="padding:0;">
+    <td style="padding:0;text-align:center;">
       <div style="font-size:14px;font-weight:bold;color:#111;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
       <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#0b57d0;text-decoration:none;">speldridge.co.uk</a></div>
+      <div style="color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#0b57d0;text-decoration:none;">speldridge.co.uk</a> · <a href="https://speldridge.tech" style="color:#0b57d0;text-decoration:none;">speldridge.tech</a></div>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding:10px 0 0;text-align:center;">
+      <a href="https://speldridge.co.uk" target="_blank" style="text-decoration:none;">
+        <img src="https://raw.githubusercontent.com/Band-Of-Brothers-B-o-B/emailsignatures/main/speldridge/logo.png"
+             alt="Speldridge" style="width:160px;height:auto;border:none;display:block;margin:0 auto;">
+      </a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- Move contact text above logo using separate table rows
- Center-align content and display both speldridge.co.uk and speldridge.tech domains

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caadab6e48328bbe706f1f019faed