### PR TITLE
feat: brand-themed email signatures

### DIFF
--- a/aividz.online/signature/index.html
+++ b/aividz.online/signature/index.html
@@ -8,11 +8,16 @@
 <table style="border-spacing:0;margin:auto;font-family:Arial,sans-serif;font-size:14px;line-height:20px;color:#111;text-align:center;">
   <tr>
     <td style="padding:0;">
-      <div style="font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="font-weight:bold;color:#101D2E;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="color:#444;">%%Company%%</div>
-      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div><a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
+      <div style="margin-top:8px;"><a href="mailto:%%Email%%" style="color:#101D2E;text-decoration:none;">%%Email%%</a></div>
+      <div><a href="https://aividz.online" style="color:#101D2E;text-decoration:none;">aividz.online</a></div>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding:8px 0 0;">
+      <div style="border-top:1px solid #00BFA5;width:80%;margin:0 auto;"></div>
     </td>
   </tr>
   <tr>

--- a/fontofmadness.uk/signature/index.html
+++ b/fontofmadness.uk/signature/index.html
@@ -1,11 +1,16 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;text-align:center;">
   <tr>
     <td style="padding:0 0 10px 0;">
-      <div style="font-size:14px;font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="font-size:14px;font-weight:bold;color:#4F46E5;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://fontofmadness.uk" style="color:#0b57d0;text-decoration:none;">fontofmadness.uk</a></div>
+      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#111827;text-decoration:none;">%%Email%%</a></div>
+      <div style="color:#444;">🌐 <a href="https://fontofmadness.uk" style="color:#111827;text-decoration:none;">fontofmadness.uk</a></div>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding:8px 0 0;">
+      <div style="border-top:1px solid #4F46E5;width:80%;margin:0 auto;"></div>
     </td>
   </tr>
   <tr>

--- a/madgodnerevar.uk/signature/index.html
+++ b/madgodnerevar.uk/signature/index.html
@@ -8,12 +8,17 @@
     </td>
   </tr>
   <tr>
+    <td style="padding:8px 0 0;">
+      <div style="border-top:1px solid #0EA5E9;width:80%;margin:0 auto;"></div>
+    </td>
+  </tr>
+  <tr>
     <td style="padding:0;">
-      <div style="font-size:14px;font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="font-size:14px;font-weight:bold;color:#0B1020;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://madgodnerevar.uk" style="color:#0b57d0;text-decoration:none;">madgodnerevar.uk</a></div>
+      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0B1020;text-decoration:none;">%%Email%%</a></div>
+      <div style="color:#444;">🌐 <a href="https://madgodnerevar.uk" style="color:#0B1020;text-decoration:none;">madgodnerevar.uk</a></div>
     </td>
   </tr>
 </table>

--- a/nebula-project.org/signature/index.html
+++ b/nebula-project.org/signature/index.html
@@ -1,11 +1,16 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;margin:0 auto;text-align:center;">
   <tr>
     <td style="padding:0;">
-      <div style="font-size:14px;font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="font-size:14px;font-weight:bold;color:#1A202C;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://nebula-project.org" style="color:#0b57d0;text-decoration:none;">nebula-project.org</a></div>
+      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#1A202C;text-decoration:none;">%%Email%%</a></div>
+      <div style="color:#444;">🌐 <a href="https://nebula-project.org" style="color:#1A202C;text-decoration:none;">nebula-project.org</a></div>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding:8px 0 0;">
+      <div style="border-top:1px solid #62EFFF;width:80%;margin:0 auto;"></div>
     </td>
   </tr>
   <tr>

--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -1,11 +1,16 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;">
   <tr>
     <td style="padding:0;text-align:center;">
-      <div style="font-size:14px;font-weight:bold;color:#111;">%%DisplayName%%</div>
+      <div style="font-size:14px;font-weight:bold;color:#100629;">%%DisplayName%%</div>
       <div style="color:#444;">%%Title%%</div>
       <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#0b57d0;text-decoration:none;">speldridge.co.uk</a> · <a href="https://speldridge.tech" style="color:#0b57d0;text-decoration:none;">speldridge.tech</a></div>
+      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#6C2EB7;text-decoration:none;">%%Email%%</a></div>
+      <div style="color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#6C2EB7;text-decoration:none;">speldridge.co.uk</a> · <a href="https://speldridge.tech" style="color:#6C2EB7;text-decoration:none;">speldridge.tech</a></div>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding:8px 0 0;text-align:center;">
+      <div style="border-top:1px solid #6C2EB7;width:80%;margin:0 auto;"></div>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Summary
- inline brand colors for signature headings and links
- accent dividers in each signature template
- ensure text colors meet 4.5:1 contrast

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb6cbe0848328929772ecef55acb0