### PR TITLE
Update logo domain colors to brand tokens

### DIFF
--- a/aividz.online/logo.svg
+++ b/aividz.online/logo.svg
@@ -13,6 +13,6 @@
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">AV</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#00BFA5">AIVidz</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">aividz.online</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#101D2E">aividz.online</text>
   </g>
 </svg>

--- a/fontofmadness.uk/logo.svg
+++ b/fontofmadness.uk/logo.svg
@@ -13,6 +13,6 @@
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="white">FM</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#111827">Font of Madness</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">fontofmadness.uk</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#4F46E5">fontofmadness.uk</text>
   </g>
 </svg>

--- a/madgodnerevar.uk/logo.svg
+++ b/madgodnerevar.uk/logo.svg
@@ -13,6 +13,6 @@
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">MGN</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#0B1020">MadGodNerevar</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">madgodnerevar.uk</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#0EA5E9">madgodnerevar.uk</text>
   </g>
 </svg>

--- a/nebula-project.org/logo.svg
+++ b/nebula-project.org/logo.svg
@@ -13,6 +13,6 @@
     <text x="48" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">NP</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#62EFFF">Nebula Project</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">nebula-project.org</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#1A202C">nebula-project.org</text>
   </g>
 </svg>

--- a/speldridge/logo.svg
+++ b/speldridge/logo.svg
@@ -13,6 +13,6 @@
     <text x="72" y="86" font-family="Arial, Helvetica, sans-serif" font-size="40" text-anchor="middle" fill="#111827">S</text>
 
     <text x="120" y="82" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="#6C2EB7">Speldridge</text>
-    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#6B7280">speldridge.co.uk · .tech</text>
+    <text x="120" y="116" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#100629">speldridge.co.uk · .tech</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- use each brand's primary color for domain text
- ensure logo canvases remain 800×220 with gradient badges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d012bd48c83289dc0165bb141c76c