### PR TITLE
ci: serialize png rendering and rebase before auto-commit

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -47,39 +47,34 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      max-parallel: 1
-      matrix:
-        folder:
-          - aividz.online
-          - fontofmadness.uk
-          - madgodnerevar.uk
-          - nebula-project.org
-          - speldridge
+    strategy: { max-parallel: 1 }
     steps:
       - uses: actions/checkout@v4
-
-      - name: Rebase onto latest main
-        run: git pull --rebase --autostash origin main
-
       - name: Install Inkscape
         run: |
           sudo apt-get update
           sudo apt-get install -y inkscape
-
-      - name: Render ${{ matrix.folder }} → PNG 320/640 (drawing bounds)
-        working-directory: ./${{ matrix.folder }}
+      - name: Render PNG 320/640 (drawing bounds)
         run: |
           set -euo pipefail
-          GTK_USE_PORTAL=0 inkscape --without-gui logo.svg --export-type=png --export-filename=logo.png   -w 320 --export-area-drawing
-          GTK_USE_PORTAL=0 inkscape --without-gui logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
-          ls -l
+          for folder in */logo.svg; do
+            dir="$(dirname "$folder")"
+            (
+              cd "$dir"
+              GTK_USE_PORTAL=0 inkscape --without-gui logo.svg --export-type=png --export-filename=logo.png   -w 320 --export-area-drawing
+              GTK_USE_PORTAL=0 inkscape --without-gui logo.svg --export-type=png --export-filename=logo@2x.png -w 640 --export-area-drawing
+              ls -l
+            )
+          done
+
+      - name: Pull latest main
+        run: git pull --rebase origin main
 
       - name: Commit rendered images
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(images): render PNGs from SVG"
           file_pattern: |
-            ${{ matrix.folder }}/logo*.png
-            ${{ matrix.folder }}/signature/*.html
+            */logo*.{svg,png}
+            */signature/*.html
           push_options: '--force-with-lease'


### PR DESCRIPTION
## Summary
- run render-pngs job sequentially to avoid conflicts
- rebase on latest main before committing rendered assets
- commit all logo SVG/PNG files and signatures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d0132243c83288889a6f2e41bbfb7