### PR TITLE
Standardize signature contact styling

### DIFF
--- a/aividz.online/signature/index.html
+++ b/aividz.online/signature/index.html
@@ -1,12 +1,14 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#111;">
   <tr>
-    <td style="padding:0 0 8px 0;color:#444;">
-      <div style="color:#111;margin-bottom:2px;">Kind regards,</div>
-      <div style="font-size:14px;font-weight:bold;color:#101D2E;">%%DisplayName%%</div>
-      <div>%%Title%%</div>
-      <div>%%Company%%</div>
-      <div style="margin-top:6px;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
-      <div>🌐 <a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
+    <td style="padding:0 0 10px 0;color:#444;">
+      <div style="font-size:12pt;color:#111;margin-bottom:2px;">Kind regards,</div>
+      <br>
+      <div style="font-size:12pt;font-weight:bold;color:#101D2E;">%%DisplayName%%</div>
+      <br>
+      <div style="font-size:12pt;color:#444;">%%Title%%</div>
+      <div style="font-size:12pt;margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0b57d0;text-decoration:none;">%%Email%%</a></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">🌐 <a href="https://aividz.online" style="color:#0b57d0;text-decoration:none;">aividz.online</a></div>
     </td>
   </tr>
   <tr>

--- a/fontofmadness.uk/signature/index.html
+++ b/fontofmadness.uk/signature/index.html
@@ -1,12 +1,14 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;">
   <tr>
     <td style="padding:0 0 10px 0;">
-      <div style="color:#111;margin-bottom:2px;">Kind regards,</div>
-      <div style="font-size:14px;font-weight:bold;color:#4F46E5;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#111827;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://fontofmadness.uk" style="color:#111827;text-decoration:none;">fontofmadness.uk</a></div>
+      <div style="font-size:12pt;color:#111;margin-bottom:2px;">Kind regards,</div>
+      <br>
+      <div style="font-size:12pt;font-weight:bold;color:#4F46E5;">%%DisplayName%%</div>
+      <br>
+      <div style="font-size:12pt;color:#444;">%%Title%%</div>
+      <div style="font-size:12pt;margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#111827;text-decoration:none;">%%Email%%</a></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">🌐 <a href="https://fontofmadness.uk" style="color:#111827;text-decoration:none;">fontofmadness.uk</a></div>
     </td>
   </tr>
   <tr>

--- a/madgodnerevar.uk/signature/index.html
+++ b/madgodnerevar.uk/signature/index.html
@@ -1,12 +1,14 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;">
   <tr>
     <td style="padding:0 0 10px 0;">
-      <div style="color:#111;margin-bottom:2px;">Kind regards,</div>
-      <div style="font-size:14px;font-weight:bold;color:#0B1020;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0B1020;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://madgodnerevar.uk" style="color:#0B1020;text-decoration:none;">madgodnerevar.uk</a></div>
+      <div style="font-size:12pt;color:#111;margin-bottom:2px;">Kind regards,</div>
+      <br>
+      <div style="font-size:12pt;font-weight:bold;color:#0B1020;">%%DisplayName%%</div>
+      <br>
+      <div style="font-size:12pt;color:#444;">%%Title%%</div>
+      <div style="font-size:12pt;margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#0B1020;text-decoration:none;">%%Email%%</a></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">🌐 <a href="https://madgodnerevar.uk" style="color:#0B1020;text-decoration:none;">madgodnerevar.uk</a></div>
     </td>
   </tr>
   <tr>

--- a/nebula-project.org/signature/index.html
+++ b/nebula-project.org/signature/index.html
@@ -8,7 +8,7 @@
       <div style="font-size:12pt;color:#444;">%%Title%%</div>
       <div style="font-size:12pt;margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
       <div style="font-size:12pt;margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#1A202C;text-decoration:none;">%%Email%%</a></div>
-      <div style="font-size:12pt;color:#444;">🌐 <a href="https://nebula-project.org" style="color:#1A202C;text-decoration:none;">nebula-project.org</a></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">🌐 <a href="https://nebula-project.org" style="color:#1A202C;text-decoration:none;">nebula-project.org</a></div>
     </td>
   </tr>
   <tr>

--- a/speldridge/signature/index.html
+++ b/speldridge/signature/index.html
@@ -1,12 +1,14 @@
 <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.4;color:#222;">
   <tr>
     <td style="padding:0 0 10px 0;text-align:center;">
-      <div style="color:#111;margin-bottom:2px;">Kind regards,</div>
-      <div style="font-size:14px;font-weight:bold;color:#100629;">%%DisplayName%%</div>
-      <div style="color:#444;">%%Title%%</div>
-      <div style="margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
-      <div style="margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#6C2EB7;text-decoration:none;">%%Email%%</a></div>
-      <div style="color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#6C2EB7;text-decoration:none;">speldridge.co.uk</a> · <a href="https://speldridge.tech" style="color:#6C2EB7;text-decoration:none;">speldridge.tech</a></div>
+      <div style="font-size:12pt;color:#111;margin-bottom:2px;">Kind regards,</div>
+      <br>
+      <div style="font-size:12pt;font-weight:bold;color:#100629;">%%DisplayName%%</div>
+      <br>
+      <div style="font-size:12pt;color:#444;">%%Title%%</div>
+      <div style="font-size:12pt;margin-top:4px;color:#111;"><strong>%%Company%%</strong></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">📧 <a href="mailto:%%Email%%" style="color:#6C2EB7;text-decoration:none;">%%Email%%</a></div>
+      <div style="font-size:12pt;margin-top:4px;color:#444;">🌐 <a href="https://speldridge.co.uk" style="color:#6C2EB7;text-decoration:none;">speldridge.co.uk</a> · <a href="https://speldridge.tech" style="color:#6C2EB7;text-decoration:none;">speldridge.tech</a></div>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Summary
- make contact blocks consistent at 12pt font with proper spacing
- add line breaks after greeting and name
- ensure contact cells use 10px bottom padding and logo rows 8px top padding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e490a5b088328a9b74ed3e65e6c8b