### PR TITLE
fix: pull latest before PNG rendering

### DIFF
--- a/.github/workflows/render-signatures.yml
+++ b/.github/workflows/render-signatures.yml
@@ -54,6 +54,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y inkscape
+      - name: Pull latest main
+        run: git pull --rebase origin main
       - name: Render PNG 320/640 (drawing bounds)
         run: |
           set -euo pipefail
@@ -66,10 +68,6 @@ jobs:
               ls -l
             )
           done
-
-      - name: Pull latest main
-        run: git pull --rebase origin main
-
       - name: Commit rendered images
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
## Summary
- pull latest main before PNG rendering to avoid merge conflicts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8eac331c8328a0573f7a79b1f9ec